### PR TITLE
Quasar 2.3.3-SNAPSHOT updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ ARCH = $(shell uname -m)
 
 ## Quasar FDW Configuration
 
-PG_CPPFLAGS = -std=c99 -g
+PG_CPPFLAGS = -std=c99
 CURL_LIB = $(shell curl-config --libs)
 MY_LIBS = $(CURL_LIB) -lyajl
 SHLIB_LINK = $(MY_LIBS)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ This FDW forwards SELECT statements to [Quasar](https://github.com/quasar-analyt
 
 The main advantage of using this FDW over alternatives is that it takes full advantage of the Quasar query engine by "pushing down" as many clauses from the PostgreSQL query to Quasar as possible. This includes WHERE, ORDER BY, and JOIN clauses.
 
+Latest Version: `v1.0rc4`
+Required Quasar Version: `2.3.3-SNAPSHOT`
+Required PostgreSQL Version: `9.4`
+
 ## Install
 
 For development installation, see [Development](#development).

--- a/quasar_fdw.control
+++ b/quasar_fdw.control
@@ -1,5 +1,5 @@
 # quasar FDW
 comment = 'Quasar Foreign Data Wrapper'
-default_version = '1.0-rc2'
+default_version = '1.0-rc3'
 module_pathname = '$libdir/quasar_fdw'
 relocatable = true

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -38,10 +38,10 @@ USE_SOURCE=
 POSTGRES_VERSION_REGEX=9.4
 
 ## User-customizable variables
-FDWVERSION=${FDWVERSION:-v1.0-rc2}
+FDWVERSION=${FDWVERSION:-v1.0-rc3}
 YAJLCLONEURL=${YAJLCLONEURL:-https://github.com/quasar-analytics/yajl}
 YAJLVERSION=${YAJLVERSION:-646b8b82ce5441db3d11b98a1049e1fcb50fe776}
-FDWCLONEURL=${FDWCLONEURL:-https://github.com/quasar-analytics/quasar_fdw}
+FDWCLONEURL=${FDWCLONEURL:-https://github.com/quasar-analytics/quasar-fdw}
 
 ##
 ## Platform agnostic installation functions

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -35,6 +35,9 @@ sed "s/default_version = .*/default_version = '$1'/" -i quasar_fdw.control
 # Replace tag in bootstrap.sh
 sed "s/FDWVERSION=.*/FDWVERSION=\${FDWVERSION:-v${1}}/" -i scripts/bootstrap.sh
 
+# Replace tag in README
+sed "s/Lastest Version:.*/Latest Version: \`v${1}\`/" -i README.md
+
 # Make tar file
 make tar
 

--- a/src/quasar_fdw.h
+++ b/src/quasar_fdw.h
@@ -121,9 +121,6 @@ typedef struct quasar_info_curl_context {
  */
 typedef struct QuasarConn
 {
-    char *post_path;            /* Path where a POST request has put data
-                                 * Needs to be DELETEd afterwards */
-
     char *server;
     char *path;
     char *full_url;

--- a/test/expected/explain.out
+++ b/test/expected/explain.out
@@ -275,11 +275,11 @@ EXPLAIN (COSTS off) SELECT count(*) FROM smallzips;
 (3 rows)
 
 EXPLAIN (COSTS off) SELECT count(*) FROM zips WHERE state IN ('CA','OR','WA');
-                                        QUERY PLAN                                        
-------------------------------------------------------------------------------------------
+                                       QUERY PLAN                                       
+----------------------------------------------------------------------------------------
  Aggregate
    ->  Foreign Scan on zips
-         Quasar query: SELECT NULL FROM "zips" WHERE (("state"  IN (['CA', 'OR', 'WA'])))
+         Quasar query: SELECT NULL FROM "zips" WHERE (("state"  IN ('CA', 'OR', 'WA')))
 (3 rows)
 
 /* Array subscripts push down correctly from 1-based to 0-based */

--- a/test/expected/explain.out
+++ b/test/expected/explain.out
@@ -297,3 +297,18 @@ EXPLAIN (COSTS off) SELECT loc FROM zipsloc WHERE loc[1+1] > 0;
    Quasar query: SELECT "loc" FROM "smallZips" WHERE ((("loc"[1]) > 0))
 (2 rows)
 
+/* Scalar array ops */
+EXPLAIN (COSTS off) SELECT * FROM smallzips WHERE state IN ('MA', 'CA');
+                                            QUERY PLAN                                             
+---------------------------------------------------------------------------------------------------
+ Foreign Scan on smallzips
+   Quasar query: SELECT "city", "pop", "state" FROM "smallZips" WHERE (("state"  IN ('MA', 'CA')))
+(2 rows)
+
+EXPLAIN (COSTS off) SELECT * FROM smallzips WHERE state IN ('MA');
+                                       QUERY PLAN                                        
+-----------------------------------------------------------------------------------------
+ Foreign Scan on smallzips
+   Quasar query: SELECT "city", "pop", "state" FROM "smallZips" WHERE (("state" = 'MA'))
+(2 rows)
+

--- a/test/expected/join.out
+++ b/test/expected/join.out
@@ -142,11 +142,11 @@ SELECT * FROM smallzips z1 RIGHT OUTER JOIN zips_missing z2 ON z1.city = z2.miss
 
 /* zips_re state field has a join_rowcount_estimate of 500 so it will use Hash join on some small joins */
 EXPLAIN (COSTS off) SELECT * FROM zips_re z1, zips_re z2 WHERE z1.state = z2.state AND z1.city IN ('BARRE', 'AGAWAM');
-                                                 QUERY PLAN                                                 
-------------------------------------------------------------------------------------------------------------
+                                                QUERY PLAN                                                
+----------------------------------------------------------------------------------------------------------
  Nested Loop
    ->  Foreign Scan on zips_re z1
-         Quasar query: SELECT "city", "pop", "state" FROM "zips" WHERE (("city"  IN (['BARRE', 'AGAWAM'])))
+         Quasar query: SELECT "city", "pop", "state" FROM "zips" WHERE (("city"  IN ('BARRE', 'AGAWAM')))
    ->  Foreign Scan on zips_re z2
          Quasar query: SELECT "city", "pop", "state" FROM "zips" WHERE ((:p1 = "state"))
 (5 rows)

--- a/test/expected/quasar.out
+++ b/test/expected/quasar.out
@@ -271,3 +271,20 @@ SELECT loc FROM zipsloc WHERE loc[1+1] > 0 ORDER BY loc[2] LIMIT 3;
  {-73.320195,42.059552}
 (3 rows)
 
+/* Scalar Array ops */
+SELECT * FROM smallzips WHERE state IN ('MA', 'CA') ORDER BY city,pop LIMIT 3;
+   city   |  pop  | state 
+----------+-------+-------
+ ADAMS    |  9901 | MA
+ AGAWAM   | 15338 | MA
+ ASHFIELD |  1535 | MA
+(3 rows)
+
+SELECT * FROM smallzips WHERE state IN ('MA') ORDER BY city,pop LIMIT 3;
+   city   |  pop  | state 
+----------+-------+-------
+ ADAMS    |  9901 | MA
+ AGAWAM   | 15338 | MA
+ ASHFIELD |  1535 | MA
+(3 rows)
+

--- a/test/sql/explain.sql
+++ b/test/sql/explain.sql
@@ -63,3 +63,6 @@ EXPLAIN (COSTS off) SELECT count(*) FROM zips WHERE state IN ('CA','OR','WA');
 /* Array subscripts push down correctly from 1-based to 0-based */
 EXPLAIN (COSTS off) SELECT loc FROM zipsloc WHERE loc[1] < 0;
 EXPLAIN (COSTS off) SELECT loc FROM zipsloc WHERE loc[1+1] > 0;
+/* Scalar array ops */
+EXPLAIN (COSTS off) SELECT * FROM smallzips WHERE state IN ('MA', 'CA');
+EXPLAIN (COSTS off) SELECT * FROM smallzips WHERE state IN ('MA');

--- a/test/sql/quasar.sql
+++ b/test/sql/quasar.sql
@@ -61,3 +61,6 @@ SELECT count(*) FROM zips WHERE state IN ('CA','OR','WA');
 /* Array subscripts push down correctly from 1-based to 0-based */
 SELECT loc FROM zipsloc WHERE loc[1] < 0 ORDER BY loc[1] LIMIT 3;
 SELECT loc FROM zipsloc WHERE loc[1+1] > 0 ORDER BY loc[2] LIMIT 3;
+/* Scalar Array ops */
+SELECT * FROM smallzips WHERE state IN ('MA', 'CA') ORDER BY city,pop LIMIT 3;
+SELECT * FROM smallzips WHERE state IN ('MA') ORDER BY city,pop LIMIT 3;


### PR DESCRIPTION
A few breaking changes on the upgrade to Quasar 2.3.3:
- Use GET /query/fs only (see #2)
- Fix IN ('x','y') to be compatible with recent 2.3.3 changes

Note that this version requires the latest version of quasar `master` branch.
