### PR TITLE
Fix a subtle bug in how memory is managed between batches of curl body.

### DIFF
--- a/src/quasar_fdw.c
+++ b/src/quasar_fdw.c
@@ -960,7 +960,7 @@ quasarIterateForeignScan(ForeignScanState *node)
     TupleTableSlot *slot;
     ExprContext *econtext;
 
-    elog(DEBUG4, "entering function %s", __func__);
+    elog(DEBUG5, "entering function %s", __func__);
 
     fsstate = (QuasarFdwScanState *)node->fdw_state;
     slot = node->ss.ss_ScanTupleSlot;
@@ -1217,8 +1217,8 @@ estimate_path_cost_size(PlannerInfo *root,
     total_cost = startup_cost + rows * cpu_per_tuple;
     retrieved_rows = rows;
 
-    elog(DEBUG1, "Estimating path cost with remote_enabled: %s %f %f",
-         sql.data, rows, total_cost);
+    elog(DEBUG1, "Estimating path cost with remote_enabled: %f %f",
+         rows, total_cost);
 
     /* Factor in the selectivity of the locally-checked quals */
     local_sel = clauselist_selectivity(root,

--- a/src/quasar_fdw.h
+++ b/src/quasar_fdw.h
@@ -47,6 +47,9 @@
 #define QUASAR_STARTUP_COST 10.0
 #define QUASAR_PER_TUPLE_COST 0.001
 
+#define P_NO_RECORD 0
+#define P_RECORD_COMPLETE 1
+#define P_RECORD_STARTED 2
 
 /*
  * FDW-specific planner information kept in RelOptInfo.fdw_private for a
@@ -108,6 +111,7 @@ typedef struct quasar_query_curl_context {
     int         num_tuples;             /* # of tuples in array */
     int         next_tuple;             /* index of next one to return */
     int         alloc_tuples;           /* Number allocated spots for tuples */
+    bool        partial_tuple;           /* Is a tuple partially parsed? */
 } quasar_query_curl_context;
 
 typedef struct quasar_info_curl_context {
@@ -165,11 +169,12 @@ void quasar_parse_alloc(quasar_parse_context *ctx,
                         Relation rel);
 void quasar_parse_free(quasar_parse_context *ctx);
 void quasar_parse_reset(quasar_parse_context *ctx);
-bool quasar_parse(quasar_parse_context *ctx,
-                  const char *buffer,
-                  size_t *buf_loc,
-                  size_t buf_size,
-                  HeapTuple *result);
+int quasar_parse(quasar_parse_context *ctx,
+                 const char *buffer,
+                 size_t *buf_loc,
+                 size_t buf_size,
+                 HeapTuple *result);
+void quasar_copy_parse_context(quasar_parse_context *ctx);
 
 /* quasar_query.c headers */
 extern void classifyConditions(PlannerInfo *root,


### PR DESCRIPTION
When a string or some other heap-allocated value is parsed early in a record, then the record is incomplete at the end of the batch of records, the memory context holding the value is reset. This causes a segfault when it is accessed to insert into the tuple. As a solution, we call datumCopy on all these values in a long-term memory context at the time of batch switching. This allows a few values to be allocated into long-term memory and not get destroyed when the batch memory is reset.